### PR TITLE
Update BG5300.baf

### DIFF
--- a/NTotSC/BAF/Area/BG5300.baf
+++ b/NTotSC/BAF/Area/BG5300.baf
@@ -8,18 +8,18 @@ END
 
  IF
  	GlobalLT("TalkedToOupaste","Global",1)
-+	Global("CaveOpen","BG5300",0)
+	Global("CaveOpen","BG5300",0)
  THEN
  	RESPONSE #100
  		TriggerActivation("Tran80PB",FALSE)
-+		SetGlobal("CaveOpen","BG5300",1)
+		SetGlobal("CaveOpen","BG5300",1)
  END
  
  IF
  	Global("TalkedToOupaste","Global",1)
-+	Global("CaveOpen","BG5300",1)
+	Global("CaveOpen","BG5300",1)
  THEN
  	RESPONSE #100
-+		SetGlobal("CaveOpen","BG5300",2)
+		SetGlobal("CaveOpen","BG5300",2)
  		TriggerActivation("Tran80PB",TRUE)
 END


### PR DESCRIPTION
I had this problem during the installation: 
[NTotSC/BAF/Area/BG5300.BAF]  ERROR at line 11 column 1-0
Near Text: 
	Failure("lexing: empty token")
ERROR: parsing [NTotSC/BAF/Area/BG5300.BAF]: Failure("lexing: empty token")
Stopping installation because of error.

It seems that removing the '+'   at the lines 11, 15 , 20 and 23 fix the error.